### PR TITLE
fix: improve session concurrency safety, error resilience, and add AG…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,187 @@
+# AGENTS.md — Coding Agent Guidelines
+
+## Project Overview
+
+Go 1.23 Kubernetes controller (Kubebuilder v4 / Operator SDK) that cleans up vSphere
+resources (VMs, folders, tags, CNS volumes, resource pools, storage policies) when
+`vsphere-capacity-manager` Lease CRDs are deleted. Uses controller-runtime v0.18.5
+and govmomi v0.52.0.
+
+Module: `github.com/openshift-splat-team/vsphere-capacity-manager-vcenter-ctrl`
+
+## Build / Lint / Test Commands
+
+```bash
+# Build
+make build                # builds bin/manager (runs manifests, generate, fmt, vet first)
+go build ./...            # quick compile check without codegen
+
+# Format and vet
+make fmt                  # go fmt ./...
+make vet                  # go vet ./...
+
+# Lint
+make lint                 # golangci-lint run (v1.54.2, config in .golangci.yml)
+make lint-fix             # golangci-lint run --fix
+
+# Unit/integration tests (uses envtest with etcd + kube-apiserver)
+make test                 # all tests except e2e, outputs cover.out
+
+# Run a single test by name (regex match)
+go test ./internal/controller/ -run "TestName" -v
+go test ./pkg/utils/ -run "TestControllerConfig_ApplyDefaults" -v
+
+# Run a single Ginkgo spec by description
+go test ./internal/controller/ -v -ginkgo.focus="description text"
+
+# Run tests in a specific file's package
+go test ./internal/controller/ -v
+go test ./pkg/utils/ -v
+
+# E2E tests (requires Kind cluster)
+make test-e2e
+
+# Code generation
+make manifests            # generate RBAC, CRD manifests via controller-gen
+make generate             # generate DeepCopy methods
+
+# Docker
+make docker-build IMG=<image>
+make docker-push IMG=<image>
+```
+
+## Project Structure
+
+```
+cmd/main.go                              # Entrypoint, manager setup
+internal/controller/
+  lease_controller.go                    # LeaseReconciler: event-driven cleanup on lease deletion
+  vsphere_object_controller.go           # VSphereObjectReconciler: scheduled cleanup (safety net)
+  protection.go                          # Pure helper functions for pattern matching / protection
+  protection_test.go                     # Ginkgo tests for protection helpers
+  lease_controller_test.go               # Ginkgo + vcsim integration tests
+  suite_test.go                          # Ginkgo/envtest suite bootstrap
+pkg/utils/
+  config.go                              # ControllerConfig: ConfigMap parsing with defaults
+  config_test.go                         # Standard Go tests for config
+  auth.go                                # K8s Secret reading for vCenter credentials
+pkg/vsphere/
+  session.go                             # vSphere session management (mutex-protected pooling)
+config/                                  # Kustomize manifests (RBAC, deployment, samples)
+vendor/                                  # Vendored dependencies (go mod vendor)
+```
+
+## Code Style
+
+### Imports
+
+Three groups separated by blank lines: (1) stdlib, (2) external, (3) internal.
+Enforced by `goimports` linter.
+
+```go
+import (
+    "context"
+    "fmt"
+    "time"
+
+    "github.com/go-logr/logr"
+    ctrl "sigs.k8s.io/controller-runtime"
+    "sigs.k8s.io/controller-runtime/pkg/client"
+
+    "github.com/openshift-splat-team/vsphere-capacity-manager-vcenter-ctrl/pkg/vsphere"
+)
+```
+
+Common aliases: `ctrl` for controller-runtime, `v1` for the Lease API types,
+`corev1`, `k8stypes`, `cnstypes`. Dot imports only in test files for Ginkgo/Gomega.
+
+### Naming
+
+- **Structs:** PascalCase, domain-descriptive. Config types suffixed with `Config`.
+- **Functions:** Verb-first. `Locked` suffix for methods that require caller to hold a mutex
+  (e.g., `sessionLocked`, `addCredentialsLocked`).
+- **Variables:** Short idiomatic Go (`ctx`, `s`, `vm`, `rp`, `dc`, `f`, `t`).
+  Booleans: `shouldDelete`, `clusterExists`, `ok`.
+- **Constants:** PascalCase exported, camelCase unexported.
+- **JSON tags:** `snake_case` (e.g., `json:"min_age_hours"`).
+- **Log keys:** `snake_case` (e.g., `"cached_leases_count"`, `"creation_timestamp"`).
+
+### Error Handling
+
+- Wrap errors with `fmt.Errorf("context: %w", err)` for traceability.
+- In multi-server loops: log error and `continue` to the next server; track `lastErr`
+  and return it after the loop if set.
+- Use `client.IgnoreNotFound(err)` for K8s API get calls.
+- Startup errors: log + `os.Exit(1)`.
+- No custom error types; vSphere faults checked via `strings.Contains(err.Error(), ...)`.
+
+### Logging
+
+- Logger: `logr.Logger` backed by `go.uber.org/zap` (via `github.com/go-logr/zapr`).
+- Structured key-value pairs: `logger.Info("message", "key", value, ...)`.
+- Sub-loggers via `logger.WithName("subsystem")` (e.g., `"tag"`, `"folder"`, `"audit"`).
+- `V(1)` for debug-level messages.
+- Dry-run messages prefixed with `[DRY RUN]`.
+- Audit logging gated on `v.Logging.EnableAuditLog`.
+
+### Context
+
+- `context.Context` is always the first function parameter.
+- `context.WithTimeout(context.Background(), 60*time.Second)` with `defer cancel()` for
+  bounded operations (secret reads, session creation).
+- `context.TODO()` only in background goroutines without a parent context.
+
+### Concurrency
+
+- `sync.Mutex` for lease cache (explicit lock/unlock, sometimes without defer for
+  fine-grained control).
+- `sync.RWMutex` for session pool (always with `defer m.mu.Unlock()`).
+- `sync.Map` for `firstSeen` tracking (no explicit locking needed).
+- Public methods acquire the lock, then delegate to `*Locked` variants.
+
+### Tests
+
+Two test styles coexist:
+
+**Ginkgo/Gomega BDD** (internal/controller/): `Describe`/`Context`/`It` hierarchy.
+Tests use the same package (whitebox). Suite bootstrapped in `suite_test.go` with envtest.
+
+```go
+var _ = Describe("Protection Helpers", func() {
+    Context("IsProtectedTag", func() {
+        It("returns true when tag matches a protected prefix", func() {
+            Expect(IsProtectedTag("us-east-ci-12345", []string{"us-"})).To(BeTrue())
+        })
+    })
+})
+```
+
+**Standard Go tests** (pkg/utils/): `TestTypeName_Behavior` naming pattern with direct
+`t.Errorf`/`t.Fatalf` assertions. No table-driven tests.
+
+### Formatting
+
+- Standard `gofmt` formatting. No strict line length limit (lines may exceed 120 chars
+  for log statements and long function signatures).
+- `lll` linter is disabled for `internal/` and `api/` paths via `.golangci.yml`.
+
+### Comments
+
+- GoDoc-style comments on all exported types and functions.
+- `TODO` comments include author: `// TODO: jcallen: ...`.
+- Kubebuilder RBAC markers: `//+kubebuilder:rbac:groups=...`.
+- Some files have Apache 2.0 license headers (kubebuilder-scaffolded ones); newer files
+  may omit them.
+
+### Reconciler Patterns
+
+- `Reconcile` returns `(ctrl.Result{}, nil)` on success, `(ctrl.Result{}, err)` on error.
+  No `RequeueAfter` is used.
+- Background scheduled work runs in goroutines started from `SetupWithManager`, using
+  `time.Sleep` loops rather than requeueing.
+- Struct embedding of `client.Client` and `*vsphere.Metadata` in reconcilers.
+
+### Dependencies
+
+- Vendored (`vendor/` directory). Run `go mod vendor` after changing `go.mod`.
+- `go.mod` has `replace` directives for `sigs.k8s.io/cluster-api` and `vm-operator`.

--- a/internal/controller/lease_controller.go
+++ b/internal/controller/lease_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -53,6 +54,12 @@ type LeaseReconciler struct {
 
 	leases  map[string]*v1.Lease
 	leaseMu sync.Mutex
+
+	// skipVMs tracks VMs that failed with "Invalid virtual machine state" to avoid
+	// retrying them on every reconcile. Key is the VM ManagedObjectReference value,
+	// value is the VM name for logging.
+	skipVMs   map[string]string
+	skipVMsMu sync.Mutex
 
 	logger logr.Logger
 }
@@ -273,10 +280,13 @@ func (r *LeaseReconciler) deleteVirtualMachinesByPortGroup(ctx context.Context, 
 		return fmt.Errorf("cluster id not found in lease")
 	}
 
+	var lastErr error
 	for server := range r.Metadata.VCenterCredentials {
 		v, err := r.Metadata.ContainerView(ctx, server)
 		if err != nil {
-			return err
+			r.logger.Error(err, "failed to create container view, continuing to next vCenter", "vcenter", server)
+			lastErr = err
+			continue
 		}
 		containerViews = append(containerViews, v)
 
@@ -287,14 +297,18 @@ func (r *LeaseReconciler) deleteVirtualMachinesByPortGroup(ctx context.Context, 
 				if strings.Contains(err.Error(), "object references is empty") {
 					continue
 				}
-				return err
+				r.logger.Error(err, "failed to retrieve networks, continuing to next vCenter", "vcenter", server, "port_group", portGroupName)
+				lastErr = err
+				continue
 			}
 
 			for _, n := range networks {
 				if len(n.Vm) > 0 {
 					vms, err := r.getFilteredVirtualMachines(ctx, n.Vm, server, clusterId)
 					if err != nil {
-						return err
+						r.logger.Error(err, "failed to get filtered VMs, continuing to next vCenter", "vcenter", server)
+						lastErr = err
+						continue
 					}
 					for _, vm := range vms {
 						shouldDelete := false
@@ -319,7 +333,9 @@ func (r *LeaseReconciler) deleteVirtualMachinesByPortGroup(ctx context.Context, 
 						if shouldDelete {
 							r.logger.Info("deleting orphaned VM", "name", vm.Name, "reason", deleteReason)
 							if err := r.deleteVirtualMachine(ctx, server, vm.Reference()); err != nil {
-								return err
+								r.logger.Error(err, "failed to delete VM, continuing", "vcenter", server, "vm_name", vm.Name)
+								lastErr = err
+								continue
 							}
 						}
 					}
@@ -331,12 +347,26 @@ func (r *LeaseReconciler) deleteVirtualMachinesByPortGroup(ctx context.Context, 
 		return err
 	}
 
+	if lastErr != nil {
+		return fmt.Errorf("VM cleanup by port group completed with errors (last: %w)", lastErr)
+	}
+
 	return nil
 }
 
 // deleteVirtualMachine powers off and destroys a VM.
 // Ensures VM is powered off before destruction.
+// VMs that previously failed with "Invalid virtual machine state" are skipped.
 func (r *LeaseReconciler) deleteVirtualMachine(ctx context.Context, server string, ref types.ManagedObjectReference) error {
+	// Check skip list first to avoid repeated attempts on VMs stuck in invalid state
+	r.skipVMsMu.Lock()
+	if name, skipped := r.skipVMs[ref.Value]; skipped {
+		r.skipVMsMu.Unlock()
+		r.logger.V(1).Info("skipping VM in invalid state", "name", name, "ref", ref.Value)
+		return nil
+	}
+	r.skipVMsMu.Unlock()
+
 	s, err := r.Metadata.Session(ctx, server)
 	if err != nil {
 		return err
@@ -367,6 +397,10 @@ func (r *LeaseReconciler) deleteVirtualMachine(ctx context.Context, server strin
 
 		switch {
 		case strings.Contains(err.Error(), "Invalid virtual machine state."):
+			r.skipVMsMu.Lock()
+			r.skipVMs[ref.Value] = objName
+			r.skipVMsMu.Unlock()
+			r.logger.Info("added VM to skip list due to invalid state - requires manual intervention in vCenter", "name", objName, "ref", ref.Value)
 			return nil
 		case strings.Contains(err.Error(), "Permission to perform this operation was denied"):
 			return nil
@@ -569,10 +603,17 @@ func (r *LeaseReconciler) deleteTagsByClusterId(ctx context.Context, leaseName s
 
 	r.logger.WithName("tags").Info("starting tag cleanup check", "lease_name", lease.Name)
 
+	var lastErr error
 	for server := range r.Metadata.VCenterCredentials {
 		if err := r.cleanupTagsOnServer(ctx, server, clusterId); err != nil {
-			return err
+			r.logger.Error(err, "failed to cleanup tags on server, continuing to next vCenter", "vcenter", server)
+			lastErr = err
+			continue
 		}
+	}
+
+	if lastErr != nil {
+		return fmt.Errorf("tag cleanup completed with errors (last: %w)", lastErr)
 	}
 
 	r.logger.WithName("tags").Info("completed tag cleanup check", "lease_name", lease.Name)
@@ -617,12 +658,19 @@ func (r *LeaseReconciler) cleanupTagsOnServer(ctx context.Context, server, clust
 // Configures logging and event filtering for lease resources.
 func (r *LeaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.leases = make(map[string]*v1.Lease)
-	zapLog, err := zap.NewProduction(zap.AddCaller())
+	r.skipVMs = make(map[string]string)
+
+	cfg := zap.NewProductionConfig()
+	cfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	zapLog, err := cfg.Build(zap.AddCaller())
 	if err != nil {
 		return err
 	}
 
 	r.logger = zapr.NewLogger(zapLog)
+
+	// Log the skip list every 8 hours so operators can see which VMs are stuck
+	go r.logSkippedVMs()
 
 	return ctrl.NewControllerManagedBy(mgr).For(&v1.Lease{}).WithEventFilter(predicate.Funcs{
 		CreateFunc:  func(createEvent event.CreateEvent) bool { return true },
@@ -630,4 +678,26 @@ func (r *LeaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		UpdateFunc:  func(updateEvent event.UpdateEvent) bool { return true },
 		GenericFunc: func(genericEvent event.GenericEvent) bool { return false },
 	}).Complete(r)
+}
+
+// logSkippedVMs periodically logs VMs that are in the skip list due to
+// "Invalid virtual machine state" errors. Runs every 8 hours.
+func (r *LeaseReconciler) logSkippedVMs() {
+	ticker := time.NewTicker(8 * time.Hour)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		r.skipVMsMu.Lock()
+		if len(r.skipVMs) > 0 {
+			names := make([]string, 0, len(r.skipVMs))
+			for _, name := range r.skipVMs {
+				names = append(names, name)
+			}
+			r.logger.WithName("skip-list").Info("VMs skipped due to invalid state - these require manual intervention in vCenter",
+				"count", len(r.skipVMs),
+				"vm_names", names,
+			)
+		}
+		r.skipVMsMu.Unlock()
+	}
 }

--- a/internal/controller/vsphere_object_controller.go
+++ b/internal/controller/vsphere_object_controller.go
@@ -140,6 +140,7 @@ func (v *VSphereObjectReconciler) buildLogger() (*zap.Logger, error) {
 		cfg = zap.NewProductionConfig()
 	}
 	cfg.Level = zap.NewAtomicLevelAt(level)
+	cfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 
 	return cfg.Build()
 }

--- a/pkg/vsphere/session.go
+++ b/pkg/vsphere/session.go
@@ -3,10 +3,14 @@ package vsphere
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/vmware/govmomi/view"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
 )
+
+const sessionTimeout = 60 * time.Second
 
 // VCenterContext maintains context of known vCenters to be used in CAPI manifest reconciliation.
 type VCenterContext struct {
@@ -21,6 +25,8 @@ type VCenterCredential struct {
 
 // Metadata holds vcenter stuff.
 type Metadata struct {
+	mu sync.RWMutex
+
 	sessions           map[string]*session.Session
 	credentials        map[string]*session.Params
 	VCenterCredentials map[string]VCenterCredential
@@ -40,6 +46,15 @@ func NewMetadata() *Metadata {
 // AddCredentials creates a session param from the vCenter server, username and password
 // to the Credentials Map.
 func (m *Metadata) AddCredentials(server, username, password string) (*session.Params, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.addCredentialsLocked(server, username, password)
+}
+
+// addCredentialsLocked is the internal implementation of AddCredentials.
+// Caller must hold m.mu.
+func (m *Metadata) addCredentialsLocked(server, username, password string) (*session.Params, error) {
 	if _, ok := m.VCenterCredentials[server]; !ok {
 		m.VCenterCredentials[server] = VCenterCredential{
 			Username: username,
@@ -63,6 +78,9 @@ func (m *Metadata) AddCredentials(server, username, password string) (*session.P
 
 // Session returns a session from unlockedSession based on the server (vCenter URL).
 func (m *Metadata) Session(ctx context.Context, server string) (*session.Session, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	// m.sessions is not stored in the json state file - there is no real reason to do this
 	// but upon returning to Session (create manifest, create cluster) the sessions map is
 	// nil, re-make it.
@@ -70,11 +88,13 @@ func (m *Metadata) Session(ctx context.Context, server string) (*session.Session
 		m.sessions = make(map[string]*session.Session)
 	}
 
-	return m.unlockedSession(ctx, server)
+	return m.sessionLocked(ctx, server)
 }
 
 func (m *Metadata) ContainerView(ctx context.Context, server string) (*view.ContainerView, error) {
-	s, err := m.unlockedSession(ctx, server)
+	m.mu.Lock()
+	s, err := m.sessionLocked(ctx, server)
+	m.mu.Unlock()
 	if err != nil {
 		return nil, err
 	}
@@ -93,11 +113,13 @@ func (m *Metadata) DestroyContainerViews(ctx context.Context, containerViews []*
 	return nil
 }
 
-func (m *Metadata) unlockedSession(ctx context.Context, server string) (*session.Session, error) {
+// sessionLocked gets or creates a session for the given server.
+// Caller must hold m.mu.
+func (m *Metadata) sessionLocked(ctx context.Context, server string) (*session.Session, error) {
 	var err error
 	if _, ok := m.credentials[server]; !ok {
 		if c, ok := m.VCenterCredentials[server]; ok {
-			_, err := m.AddCredentials(server, c.Username, c.Password)
+			_, err := m.addCredentialsLocked(server, c.Username, c.Password)
 			if err != nil {
 				return nil, err
 			}
@@ -106,11 +128,16 @@ func (m *Metadata) unlockedSession(ctx context.Context, server string) (*session
 		}
 	}
 
+	// Apply a timeout to prevent a single unresponsive vCenter from blocking
+	// the global session mutex indefinitely.
+	timeoutCtx, cancel := context.WithTimeout(ctx, sessionTimeout)
+	defer cancel()
+
 	// We are going to keep this simple since session is
 	// caching the session anyway. Always set the m.sessions[server]
-	m.sessions[server], err = session.GetOrCreate(ctx, m.credentials[server])
+	m.sessions[server], err = session.GetOrCreate(timeoutCtx, m.credentials[server])
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("session for %s: %w", server, err)
 	}
 
 	return m.sessions[server], nil


### PR DESCRIPTION
…ENTS.md

Add mutex protection (sync.RWMutex) to Metadata session pool to prevent concurrent map read/write panics. Introduce Locked method pattern where public methods acquire the lock and delegate to *Locked variants.

Improve error resilience in lease controller by replacing early returns with log-and-continue in multi-vCenter loops, tracking lastErr for partial failure reporting. Add skip list for VMs stuck in invalid state to avoid repeated retry attempts, with periodic (8h) operator logging.

Standardize zap logger timestamps to ISO8601 across both controllers. Add 60s context timeout to session creation to prevent mutex starvation from unresponsive vCenters.

Add AGENTS.md with build/test commands, code style guidelines, and project structure documentation for agentic coding tools.