### PR TITLE
fix: resolve session deadline exceeded by eliminating mutex contention

### DIFF
--- a/pkg/vsphere/session.go
+++ b/pkg/vsphere/session.go
@@ -10,7 +10,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
 )
 
-const sessionTimeout = 60 * time.Second
+const sessionTimeout = 120 * time.Second
 
 // VCenterContext maintains context of known vCenters to be used in CAPI manifest reconciliation.
 type VCenterContext struct {
@@ -25,7 +25,14 @@ type VCenterCredential struct {
 
 // Metadata holds vcenter stuff.
 type Metadata struct {
-	mu sync.RWMutex
+	// mu protects the sessions, credentials, and VCenterCredentials maps,
+	// as well as the serverMu map. Hold briefly to read/write map entries;
+	// never hold across network calls.
+	mu sync.Mutex
+
+	// serverMu provides per-server mutexes so that session creation for
+	// one vCenter does not block session creation for another.
+	serverMu map[string]*sync.Mutex
 
 	sessions           map[string]*session.Session
 	credentials        map[string]*session.Params
@@ -37,6 +44,7 @@ type Metadata struct {
 // NewMetadata initializes a new Metadata object.
 func NewMetadata() *Metadata {
 	return &Metadata{
+		serverMu:           make(map[string]*sync.Mutex),
 		sessions:           make(map[string]*session.Session),
 		credentials:        make(map[string]*session.Params),
 		VCenterCredentials: make(map[string]VCenterCredential),
@@ -76,47 +84,10 @@ func (m *Metadata) addCredentialsLocked(server, username, password string) (*ses
 	return m.credentials[server], nil
 }
 
-// Session returns a session from unlockedSession based on the server (vCenter URL).
-func (m *Metadata) Session(ctx context.Context, server string) (*session.Session, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// m.sessions is not stored in the json state file - there is no real reason to do this
-	// but upon returning to Session (create manifest, create cluster) the sessions map is
-	// nil, re-make it.
-	if m.sessions == nil {
-		m.sessions = make(map[string]*session.Session)
-	}
-
-	return m.sessionLocked(ctx, server)
-}
-
-func (m *Metadata) ContainerView(ctx context.Context, server string) (*view.ContainerView, error) {
-	m.mu.Lock()
-	s, err := m.sessionLocked(ctx, server)
-	m.mu.Unlock()
-	if err != nil {
-		return nil, err
-	}
-
-	viewMgr := view.NewManager(s.Client.Client)
-	return viewMgr.CreateContainerView(ctx, s.Client.ServiceContent.RootFolder, nil, true)
-}
-
-func (m *Metadata) DestroyContainerViews(ctx context.Context, containerViews []*view.ContainerView) error {
-	for _, v := range containerViews {
-		if err := v.Destroy(ctx); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// sessionLocked gets or creates a session for the given server.
+// getCredentialsLocked returns session.Params for the given server, building
+// them from VCenterCredentials if they don't already exist.
 // Caller must hold m.mu.
-func (m *Metadata) sessionLocked(ctx context.Context, server string) (*session.Session, error) {
-	var err error
+func (m *Metadata) getCredentialsLocked(server string) (*session.Params, error) {
 	if _, ok := m.credentials[server]; !ok {
 		if c, ok := m.VCenterCredentials[server]; ok {
 			_, err := m.addCredentialsLocked(server, c.Username, c.Password)
@@ -128,17 +99,84 @@ func (m *Metadata) sessionLocked(ctx context.Context, server string) (*session.S
 		}
 	}
 
-	// Apply a timeout to prevent a single unresponsive vCenter from blocking
-	// the global session mutex indefinitely.
+	return m.credentials[server], nil
+}
+
+// serverMuLocked returns the per-server mutex, creating one if needed.
+// Caller must hold m.mu.
+func (m *Metadata) serverMuLocked(server string) *sync.Mutex {
+	if m.serverMu == nil {
+		m.serverMu = make(map[string]*sync.Mutex)
+	}
+	mu, ok := m.serverMu[server]
+	if !ok {
+		mu = &sync.Mutex{}
+		m.serverMu[server] = mu
+	}
+	return mu
+}
+
+// Session returns a session for the given vCenter server.
+// Uses per-server locking so that a slow vCenter does not block other servers,
+// and releases the global mutex before making network calls to avoid holding
+// it during potentially long session.GetOrCreate operations.
+func (m *Metadata) Session(ctx context.Context, server string) (*session.Session, error) {
+	// Phase 1: Read credentials and get the per-server mutex under the global lock.
+	m.mu.Lock()
+
+	if m.sessions == nil {
+		m.sessions = make(map[string]*session.Session)
+	}
+
+	params, err := m.getCredentialsLocked(server)
+	if err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+
+	smu := m.serverMuLocked(server)
+	m.mu.Unlock()
+
+	// Phase 2: Acquire the per-server lock and perform the (potentially slow)
+	// network call to GetOrCreate without holding the global lock.
+	smu.Lock()
+	defer smu.Unlock()
+
 	timeoutCtx, cancel := context.WithTimeout(ctx, sessionTimeout)
 	defer cancel()
 
-	// We are going to keep this simple since session is
-	// caching the session anyway. Always set the m.sessions[server]
-	m.sessions[server], err = session.GetOrCreate(timeoutCtx, m.credentials[server])
+	s, err := session.GetOrCreate(timeoutCtx, params)
 	if err != nil {
 		return nil, fmt.Errorf("session for %s: %w", server, err)
 	}
 
-	return m.sessions[server], nil
+	// Phase 3: Store the session result under the global lock.
+	m.mu.Lock()
+	m.sessions[server] = s
+	m.mu.Unlock()
+
+	return s, nil
+}
+
+// ContainerView creates a new container view for the given vCenter server.
+// Each call creates a fresh view; callers must destroy it via DestroyContainerViews.
+func (m *Metadata) ContainerView(ctx context.Context, server string) (*view.ContainerView, error) {
+	s, err := m.Session(ctx, server)
+	if err != nil {
+		return nil, err
+	}
+
+	viewMgr := view.NewManager(s.Client.Client)
+	return viewMgr.CreateContainerView(ctx, s.Client.ServiceContent.RootFolder, nil, true)
+}
+
+// DestroyContainerViews destroys a list of container views.
+func (m *Metadata) DestroyContainerViews(ctx context.Context, containerViews []*view.ContainerView) error {
+	for _, v := range containerViews {
+		if err := v.Destroy(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Release the global Metadata mutex before calling session.GetOrCreate to prevent a single slow or stale vCenter session from blocking all other reconcile goroutines. Previously the mutex was held across the entire GetOrCreate call (which itself acquires CAPV's sessionMU and makes multiple network calls for session health checks, logout, and re-login), causing cascading context deadline exceeded errors.

Introduce per-server mutexes (map[string]*sync.Mutex) so that session creation for one vCenter does not serialize behind another. The global mutex is now only held briefly to read credentials and access the per-server mutex map.

Increase sessionTimeout from 60s to 120s to accommodate the full CAPV session lifecycle (cached session health check, logout, SOAP client creation, login, REST client creation) when sessions go stale.