### PR TITLE
fix: correct resource pool protection semantics and add lease-driven …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,93 @@
+# Changelog
+
+All notable changes to the vSphere Capacity Manager vCenter Controller will be
+documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Fixed
+
+- **CRITICAL: Resource pool protection semantics inversion in VSphereObjectReconciler.**
+  The `protection.resourcepools` config field was being used as the **target list**
+  (pools to delete) instead of a **protection list** (pools to protect from deletion).
+  This was the opposite semantic from `protection.tags` and `protection.folders`, which
+  correctly protect matching objects. Resource pool target prefixes (`ci-`, `qeci-`) are
+  now hardcoded in `DefaultResourcePoolTargetPrefixes` (matching the `DefaultFolderTargetPatterns`
+  pattern), and `protection.resourcepools` is now correctly used to **protect** pools
+  from deletion via the new `IsProtectedResourcePool` helper function.
+  (`internal/controller/protection.go`, `internal/controller/vsphere_object_controller.go`)
+
+- **CRITICAL: LeaseReconciler had no resource pool protection.**
+  When a Lease was deleted, the `LeaseReconciler` would search for all `ManagedEntity`
+  objects matching the cluster ID via wildcard (`getManagedEntitiesByClusterId`). Any
+  `ResourcePool` matching the pattern fell through to the `default` case in
+  `deleteByManagedEntity` and was destroyed with no protection check, no empty-pool
+  check, no dry-run check, and no minimum age check. This caused the `ipi-ci-clusters`
+  resource pool to be deleted despite being listed in the protection config.
+  The fix adds an explicit `"ResourcePool"` case in `deleteByManagedEntity` that checks
+  `IsProtectedResourcePool` before deletion, and wires the `Protection` config into
+  the `LeaseReconciler` struct.
+  (`internal/controller/lease_controller.go`, `cmd/main.go`)
+
+### Changed
+
+- `protection.resourcepools` config field now has **protection semantics** (matching
+  tags and folders). Values are prefixes of resource pool names that should be
+  **protected from deletion**, not targeted for deletion. **This is a breaking change
+  for anyone who was relying on the old (incorrect) behavior of using this field as a
+  target list.**
+
+- Default value for `protection.resourcepools` is now empty (no pools protected by
+  default). Previously defaulted to `["ci-", "qeci-"]` which were being used as
+  deletion targets. Target prefixes are now hardcoded in
+  `DefaultResourcePoolTargetPrefixes`.
+
+### Added
+
+- `DefaultResourcePoolTargetPrefixes` variable in `internal/controller/protection.go` --
+  hardcoded `["ci-", "qeci-"]` target prefixes for resource pool cleanup, following the
+  same pattern as `DefaultFolderTargetPatterns`.
+
+- `IsProtectedResourcePool` function in `internal/controller/protection.go` -- checks
+  whether a resource pool name starts with any protected prefix. Used by both
+  `VSphereObjectReconciler` and `LeaseReconciler`.
+
+- `Protection` field (`utils.ProtectionConfig`) on `LeaseReconciler` struct, wired
+  from `controllerConfig.Protection` in `cmd/main.go`.
+
+- Explicit `"ResourcePool"` case in `LeaseReconciler.deleteByManagedEntity` with
+  protection check before deletion.
+
+- Tests for `IsProtectedResourcePool` in `internal/controller/protection_test.go`,
+  including interaction tests verifying that a pool can match a target prefix while
+  being protected.
+
+- Test for `DefaultResourcePoolTargetPrefixes` verifying that `ipi-ci-clusters` is
+  not a target (does not start with `ci-` or `qeci-`).
+
+### Migration Guide
+
+If you have an existing config with `protection.resourcepools`, update it to list
+pools you want to **protect** (not pools you want to target for deletion):
+
+```yaml
+# BEFORE (old broken semantics -- these were deletion targets, not protection):
+protection:
+  resourcepools:
+    - ci-
+    - qeci-
+
+# AFTER (correct semantics -- these are protected from deletion):
+protection:
+  resourcepools:
+    - ipi-ci-clusters
+    - management-pool
+```
+
+Target prefixes (`ci-`, `qeci-`) are now built into the controller as
+`DefaultResourcePoolTargetPrefixes` and do not need to be configured. Any resource
+pool whose name starts with `ci-` or `qeci-` will be a candidate for cleanup
+(if empty and old enough in the scheduled path, or if matched by cluster ID in the
+lease path) **unless** it is explicitly protected via `protection.resourcepools`.

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -10,11 +10,15 @@ The controller performs two types of operations:
 
 ## ConfigMap Configuration
 
-A ConfigMap can be used to configure operational parameters (future implementation). See `config/samples/cleanup-config.yaml` for the template.
+The controller reads its configuration from a Kubernetes ConfigMap. See
+`config/samples/cleanup-config.yaml` for a complete template.
 
-### Current Hard-Coded Settings
+Configuration is parsed by `pkg/utils/config.go` (`ReadControllerConfig`) and loaded
+once at startup. Changes to the ConfigMap require a pod restart to take effect.
 
-The following settings are currently hard-coded in the controller but can be made configurable in future versions:
+### Configurable Settings
+
+The following settings are configured via the ConfigMap with sensible defaults:
 
 #### Cleanup Intervals
 
@@ -43,11 +47,29 @@ The following settings are currently hard-coded in the controller but can be mad
 
 #### Protected Resources
 
-| Resource Type | Protection Logic | Location |
-|--------------|------------------|----------|
-| Zonal tags | Tags starting with `us-` | `vsphere_object_controller.go:252` |
-| System folders | "debug" folder | `vsphere_object_controller.go` (via getFolderList) |
-| RHCOS VMs | VMs starting with `rhcos-` | `lease_controller.go:233` |
+All protection prefixes/names are configurable via the `protection` section of the
+ConfigMap. The controller uses a two-tier model for cleanup decisions:
+
+1. **Target patterns** (hardcoded): identify resources that are candidates for deletion
+2. **Protection lists** (from config): exempt specific resources from deletion, even if
+   they match a target pattern
+
+| Resource Type | Target Logic | Protection Config | Default Protection |
+|--------------|--------------|-------------------|--------------------|
+| Tags | Contains `ci-` | `protection.tags` (prefix match) | `["us-"]` |
+| Folders | Contains `ci-`, `user-`, `build-` | `protection.folders` (exact match) | `["debug", "template"]` |
+| Resource pools | Starts with `ci-`, `qeci-` | `protection.resourcepools` (prefix match) | none |
+| RHCOS VMs | N/A | Hardcoded `rhcos-` prefix skip | N/A |
+
+**Example:** A resource pool named `ci-special-pool` starts with `ci-` so it is a
+cleanup target. But if `protection.resourcepools` contains `ci-special-`, the pool
+will be protected and skipped.
+
+**Location in code:**
+- Target patterns: `internal/controller/protection.go` (`DefaultFolderTargetPatterns`, `DefaultResourcePoolTargetPrefixes`)
+- Protection helpers: `internal/controller/protection.go` (`IsProtectedTag`, `IsProtectedFolder`, `IsProtectedResourcePool`)
+- Scheduled cleanup: `internal/controller/vsphere_object_controller.go`
+- Lease-driven cleanup: `internal/controller/lease_controller.go` (`deleteByManagedEntity`)
 
 ## Cleanup Operations
 
@@ -93,14 +115,24 @@ The following settings are currently hard-coded in the controller but can be mad
 ### 4. Resource Pool Cleanup (`resourcepool()`)
 **Schedule:** Every 2 hours
 **Criteria:**
-- Resource pool name starts with `ci-` or `qeci-`
+- Resource pool name starts with a target prefix (`ci-` or `qeci-`, hardcoded in `DefaultResourcePoolTargetPrefixes`)
+- Resource pool is NOT in the `protection.resourcepools` list
 - Resource pool has zero VMs
+- Resource pool has been seen as empty for at least `min_age_hours` (default: 2 hours)
 
 **Safety:**
+- Two-tier targeting: must match a target prefix AND must not match a protection prefix
 - Only deletes empty pools
 - Uses property collector to verify VM count
+- Minimum age check prevents deleting pools that were only briefly empty
+- Dry-run mode support via `features.dry_run`
 
-**Code:** `vsphere_object_controller.go:315-393`
+**Lease-driven cleanup:**
+When a Lease is deleted, the `LeaseReconciler` searches for all managed entities matching
+the cluster ID. Resource pools found this way are checked against `protection.resourcepools`
+before deletion. Protected pools are skipped with a log message.
+
+**Code:** `vsphere_object_controller.go` (`resourcepool` function), `lease_controller.go` (`deleteByManagedEntity`)
 
 ### 5. Storage Policy Cleanup (`storagepolicy()`)
 **Schedule:** Every 12 hours
@@ -167,9 +199,27 @@ The following settings are currently hard-coded in the controller but can be mad
    - Deletion reasons logged for audit trail
    - Success and failure states clearly indicated
 
-### Future Enhancements (Not Yet Implemented)
+### Implemented Safety Features
 
-The following safety features are planned but not yet implemented:
+1. **Dry-Run Mode** (`features.dry_run: true`)
+   - Logs what would be deleted with `[DRY RUN]` prefix without actually deleting
+   - Available for all scheduled cleanup operations
+   - Enabled via the `features` section of the ConfigMap
+
+2. **Minimum Age Requirements** (`safety.min_age_hours`)
+   - Configurable minimum age (default: 2 hours) for scheduled cleanup targets
+   - Resources must be seen as deletion candidates for at least this long before
+     they are actually deleted
+   - Kubevols have a separate `safety.kubevols_min_age_days` threshold (default: 21 days)
+
+3. **Grace Periods** (`safety.grace_period_hours`)
+   - Configurable grace period (default: 12 hours) after cluster deletion
+
+4. **Configurable Protection Lists**
+   - Tags, folders, and resource pools can be protected via the `protection` section
+   - See "Protected Resources" above for details
+
+### Future Enhancements (Not Yet Implemented)
 
 1. **Circuit Breaker**
    - Maximum deletions per run (e.g., 100)
@@ -181,21 +231,6 @@ The following safety features are planned but not yet implemented:
    - Confirm after waiting period
    - Execute deletion
    - Provides time for manual intervention
-
-3. **Dry-Run Mode**
-   - Log what would be deleted without actually deleting
-   - Test cleanup logic safely
-   - Validate before production deployment
-
-4. **Minimum Age Requirements**
-   - Configurable minimum age for all resources
-   - Additional buffer beyond lease lifecycle
-   - Currently only implemented for kubevols (21 days)
-
-5. **Grace Periods**
-   - Time window after cluster deletion before resource cleanup
-   - Allows for manual recovery if needed
-   - Currently not implemented
 
 ## Deployment Configuration
 
@@ -239,50 +274,75 @@ Currently, the controller exposes standard controller-runtime metrics. Future en
 - `vsphere_cleanup_duration_seconds{operation}` - Histogram of cleanup durations
 - `vsphere_cleanup_errors_total{operation}` - Counter of cleanup errors
 
-## Future Configuration Implementation
+## Configuration Reference
 
-To implement ConfigMap-based configuration:
+### Protection Section
 
-1. **Add ConfigMap mounting** in deployment:
 ```yaml
-volumeMounts:
-- name: config
-  mountPath: /etc/vsphere-cleanup
-volumes:
-- name: config
-  configMap:
-    name: vsphere-cleanup-config
+protection:
+  # Tag name prefixes to protect from deletion (prefix match).
+  # Tags whose names start with any of these prefixes will be skipped.
+  # Default: ["us-"]
+  tags:
+    - us-east
+    - us-west
+
+  # Folder names to protect from deletion (exact match).
+  # Folders whose names exactly match any of these will be skipped.
+  # Default: ["debug", "template"]
+  folders:
+    - debug
+    - template
+    - management
+
+  # Resource pool name prefixes to protect from deletion (prefix match).
+  # Resource pools whose names start with any of these prefixes will be
+  # skipped, even if they match the built-in target prefixes (ci-, qeci-).
+  # Default: [] (no pools protected by default)
+  resourcepools:
+    - ipi-ci-clusters
+    - management-
 ```
 
-2. **Update controller code** to read config:
-```go
-// Add to main.go or controller setup
-import "github.com/spf13/viper"
+### Features Section
 
-viper.SetConfigName("cleanup-config")
-viper.AddConfigPath("/etc/vsphere-cleanup")
-viper.AutomaticEnv()
+```yaml
+features:
+  # When true, log what would be deleted without actually deleting.
+  dry_run: false
 
-// Read intervals
-folderInterval := viper.GetDuration("cleanup.intervals.folders")
+  # Enable/disable individual cleanup operations.
+  # If all flags are omitted, all operations are enabled by default.
+  enable_folders: true
+  enable_tags: true
+  enable_cnsvolumes: true
+  enable_resourcepools: true
+  enable_storagepolicies: true
+  enable_kubevols: true
 ```
 
-3. **Apply configuration** to pruneFunctions:
-```go
-pf := []pruneFunctions{
-    {
-        name:    "folders",
-        execute: v.folder,
-        delay:   config.GetDuration("cleanup.intervals.folders"),
-        lastRun: time.Now(),
-    },
-    // ...
-}
+### Safety Section
+
+```yaml
+safety:
+  # Minimum hours a resource must be seen as a deletion candidate before
+  # it is actually deleted. Default: 2
+  min_age_hours: 2
+
+  # Grace period in hours after cluster deletion. Default: 12
+  grace_period_hours: 12
+
+  # Minimum age in days for kubevol VMDK files before deletion. Default: 21
+  kubevols_min_age_days: 21
 ```
 
 ## References
 
 - Main controller: `internal/controller/vsphere_object_controller.go`
 - Lease reconciler: `internal/controller/lease_controller.go`
+- Protection helpers: `internal/controller/protection.go`
+- Config parsing: `pkg/utils/config.go`
+- Sample config: `config/samples/cleanup-config.yaml`
+- Changelog: `CHANGELOG.md`
 - Implementation plan: `IMPLEMENTATION_PLAN.md`
 - Deployment: `deploy.yaml`

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -156,9 +156,10 @@ func main() {
 	}
 
 	if err = (&controller.LeaseReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Metadata: metadata,
+		Client:     mgr.GetClient(),
+		Scheme:     mgr.GetScheme(),
+		Metadata:   metadata,
+		Protection: controllerConfig.Protection,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Lease")
 		os.Exit(1)

--- a/config/samples/cleanup-config.yaml
+++ b/config/samples/cleanup-config.yaml
@@ -42,9 +42,10 @@ data:
       folders:
         - debug
         - template
+      # Resource pools matching these prefixes are protected from deletion,
+      # even if they match the built-in target prefixes (ci-, qeci-).
       resourcepools:
-        - ci-
-        - qeci-
+        - ipi-ci-clusters
 
     logging:
       level: info

--- a/internal/controller/lease_controller.go
+++ b/internal/controller/lease_controller.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	"github.com/openshift-splat-team/vsphere-capacity-manager-vcenter-ctrl/pkg/utils"
 	"github.com/openshift-splat-team/vsphere-capacity-manager-vcenter-ctrl/pkg/vsphere"
 	v1 "github.com/openshift-splat-team/vsphere-capacity-manager/pkg/apis/vspherecapacitymanager.splat.io/v1"
 )
@@ -51,6 +52,8 @@ type LeaseReconciler struct {
 	Scheme *runtime.Scheme
 
 	*vsphere.Metadata
+
+	Protection utils.ProtectionConfig
 
 	leases  map[string]*v1.Lease
 	leaseMu sync.Mutex
@@ -556,6 +559,15 @@ func (r *LeaseReconciler) deleteByManagedEntity(ctx context.Context, managedEnti
 					r.logger.Error(err, "failed to delete managed entity", "entity", managedEntity.Name)
 					continue
 				}
+			}
+		case "ResourcePool":
+			if IsProtectedResourcePool(managedEntity.Name, r.Protection.ResourcePools) {
+				r.logger.WithName("deleteByManagedEntity").Info("skipping protected resource pool", "name", managedEntity.Name)
+				continue
+			}
+			if err := deleteManagedEntity(ctx, managedEntity, s.Client.Client); err != nil {
+				r.logger.Error(err, "failed to destroy resource pool", "entity", managedEntity.Name)
+				continue
 			}
 		default:
 			if err := deleteManagedEntity(ctx, managedEntity, s.Client.Client); err != nil {

--- a/internal/controller/protection.go
+++ b/internal/controller/protection.go
@@ -5,6 +5,11 @@ import "strings"
 // DefaultFolderTargetPatterns are the default patterns used to identify CI/test folders.
 var DefaultFolderTargetPatterns = []string{"ci-", "user-", "build-"}
 
+// DefaultResourcePoolTargetPrefixes are the default prefixes used to identify CI/test resource pools
+// that are candidates for cleanup. Resource pools whose names start with these prefixes may be
+// deleted if they are empty and not explicitly protected via the protection config.
+var DefaultResourcePoolTargetPrefixes = []string{"ci-", "qeci-"}
+
 // IsProtectedTag returns true if tagName starts with any of the protected prefixes.
 func IsProtectedTag(tagName string, protectedPrefixes []string) bool {
 	for _, prefix := range protectedPrefixes {
@@ -38,6 +43,17 @@ func IsProtectedFolder(folderName string, protectedFolders []string) bool {
 // IsTargetResourcePool returns true if rpName starts with any of the target prefixes.
 func IsTargetResourcePool(rpName string, targetPrefixes []string) bool {
 	for _, prefix := range targetPrefixes {
+		if strings.HasPrefix(rpName, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsProtectedResourcePool returns true if rpName starts with any of the protected prefixes.
+// Protected resource pools are exempt from cleanup even if they match target prefixes.
+func IsProtectedResourcePool(rpName string, protectedPrefixes []string) bool {
+	for _, prefix := range protectedPrefixes {
 		if strings.HasPrefix(rpName, prefix) {
 			return true
 		}

--- a/internal/controller/protection_test.go
+++ b/internal/controller/protection_test.go
@@ -94,6 +94,52 @@ var _ = Describe("Protection Helpers", func() {
 		It("returns false when prefix list is empty", func() {
 			Expect(IsTargetResourcePool("ci-12345", []string{})).To(BeFalse())
 		})
+
+		It("uses DefaultResourcePoolTargetPrefixes correctly", func() {
+			Expect(IsTargetResourcePool("ci-op-abc", DefaultResourcePoolTargetPrefixes)).To(BeTrue())
+			Expect(IsTargetResourcePool("qeci-xyz", DefaultResourcePoolTargetPrefixes)).To(BeTrue())
+			Expect(IsTargetResourcePool("ipi-ci-clusters", DefaultResourcePoolTargetPrefixes)).To(BeFalse())
+			Expect(IsTargetResourcePool("production", DefaultResourcePoolTargetPrefixes)).To(BeFalse())
+		})
+	})
+
+	Context("IsProtectedResourcePool", func() {
+		It("returns true when name matches a protected prefix", func() {
+			Expect(IsProtectedResourcePool("ipi-ci-clusters", []string{"ipi-"})).To(BeTrue())
+		})
+
+		It("returns true on exact match with prefix", func() {
+			Expect(IsProtectedResourcePool("ipi-ci-clusters", []string{"ipi-ci-clusters"})).To(BeTrue())
+		})
+
+		It("returns false when name does not match any protected prefix", func() {
+			Expect(IsProtectedResourcePool("ci-op-12345", []string{"ipi-", "management-"})).To(BeFalse())
+		})
+
+		It("returns false when protected list is empty", func() {
+			Expect(IsProtectedResourcePool("ipi-ci-clusters", []string{})).To(BeFalse())
+		})
+
+		It("returns false when name is empty", func() {
+			Expect(IsProtectedResourcePool("", []string{"ipi-"})).To(BeFalse())
+		})
+
+		It("matches against multiple prefixes", func() {
+			prefixes := []string{"ipi-", "management-", "prod-"}
+			Expect(IsProtectedResourcePool("ipi-ci-clusters", prefixes)).To(BeTrue())
+			Expect(IsProtectedResourcePool("management-pool", prefixes)).To(BeTrue())
+			Expect(IsProtectedResourcePool("prod-workloads", prefixes)).To(BeTrue())
+			Expect(IsProtectedResourcePool("ci-op-12345", prefixes)).To(BeFalse())
+		})
+
+		It("protects a resource pool that also matches target prefixes", func() {
+			// A pool starting with "ci-" is a target, but if it's also protected it should be skipped
+			targetPrefixes := DefaultResourcePoolTargetPrefixes
+			protectedPrefixes := []string{"ci-special-"}
+			rpName := "ci-special-pool"
+			Expect(IsTargetResourcePool(rpName, targetPrefixes)).To(BeTrue())
+			Expect(IsProtectedResourcePool(rpName, protectedPrefixes)).To(BeTrue())
+		})
 	})
 
 	Context("IsTargetStoragePolicy", func() {

--- a/internal/controller/vsphere_object_controller.go
+++ b/internal/controller/vsphere_object_controller.go
@@ -463,7 +463,13 @@ func (v *VSphereObjectReconciler) resourcepool(ctx context.Context) error {
 				rpName := rp.Name()
 
 				// Only process resource pools matching target prefixes
-				if !IsTargetResourcePool(rpName, v.Protection.ResourcePools) {
+				if !IsTargetResourcePool(rpName, DefaultResourcePoolTargetPrefixes) {
+					continue
+				}
+
+				// Skip resource pools that are explicitly protected
+				if IsProtectedResourcePool(rpName, v.Protection.ResourcePools) {
+					v.logger.WithName("resourcepool").Info("skipping protected resource pool", "name", rpName)
 					continue
 				}
 

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -11,6 +11,9 @@ import (
 )
 
 // ProtectionConfig defines prefixes/patterns used to protect vSphere objects from cleanup.
+// Tags: tag name prefixes to protect from deletion.
+// Folders: exact folder names to protect from deletion.
+// ResourcePools: resource pool name prefixes to protect from deletion.
 type ProtectionConfig struct {
 	Tags          []string `json:"tags"`
 	Folders       []string `json:"folders"`
@@ -110,9 +113,9 @@ func (c *ControllerConfig) applyDefaults() {
 	if len(c.Protection.Folders) == 0 {
 		c.Protection.Folders = []string{"debug", "template"}
 	}
-	if len(c.Protection.ResourcePools) == 0 {
-		c.Protection.ResourcePools = []string{"ci-", "qeci-"}
-	}
+	// No default protection prefixes for resource pools.
+	// Target prefixes are hardcoded in DefaultResourcePoolTargetPrefixes.
+	// protection.resourcepools is used to PROTECT specific pools from deletion.
 
 	// Safety defaults
 	if c.Safety.MinAgeHours == 0 {

--- a/pkg/utils/config_test.go
+++ b/pkg/utils/config_test.go
@@ -53,8 +53,8 @@ func TestControllerConfig_ApplyDefaults(t *testing.T) {
 	if len(config.Protection.Folders) != 2 || config.Protection.Folders[0] != "debug" {
 		t.Errorf("expected default folders [debug, template], got %v", config.Protection.Folders)
 	}
-	if len(config.Protection.ResourcePools) != 2 || config.Protection.ResourcePools[0] != "ci-" {
-		t.Errorf("expected default resourcepools [ci-, qeci-], got %v", config.Protection.ResourcePools)
+	if len(config.Protection.ResourcePools) != 0 {
+		t.Errorf("expected default resourcepools to be empty (no defaults), got %v", config.Protection.ResourcePools)
 	}
 	if config.Safety.KubevolsMinAgeDays != 21 {
 		t.Errorf("expected default kubevols_min_age_days 21, got %d", config.Safety.KubevolsMinAgeDays)
@@ -82,12 +82,12 @@ safety:
 	if len(config.Protection.Tags) != 1 || config.Protection.Tags[0] != "eu-" {
 		t.Errorf("expected tags [eu-], got %v", config.Protection.Tags)
 	}
-	// Folders and ResourcePools should get defaults since they weren't set
+	// Folders should get defaults since they weren't set; ResourcePools has no defaults
 	if len(config.Protection.Folders) != 2 || config.Protection.Folders[0] != "debug" {
 		t.Errorf("expected default folders [debug, template], got %v", config.Protection.Folders)
 	}
-	if len(config.Protection.ResourcePools) != 2 || config.Protection.ResourcePools[0] != "ci-" {
-		t.Errorf("expected default resourcepools [ci-, qeci-], got %v", config.Protection.ResourcePools)
+	if len(config.Protection.ResourcePools) != 0 {
+		t.Errorf("expected default resourcepools to be empty (no defaults), got %v", config.Protection.ResourcePools)
 	}
 	// Safety should keep the override
 	if config.Safety.KubevolsMinAgeDays != 14 {


### PR DESCRIPTION
…protection

The protection.resourcepools config field was being used as the target list (pools to delete) instead of a protection list (pools to protect), the opposite semantic from protection.tags and protection.folders. Additionally, the LeaseReconciler had no resource pool protection at all -- pools fell through to the default case in deleteByManagedEntity and were destroyed unconditionally.

This caused ipi-ci-clusters to be deleted despite being in the protection config.

Changes:
- Add DefaultResourcePoolTargetPrefixes (ci-, qeci-) as hardcoded targets
- Add IsProtectedResourcePool helper for prefix-based protection matching
- Fix VSphereObjectReconciler.resourcepool() to use target prefixes for targeting and protection prefixes for exemption
- Add explicit ResourcePool case in LeaseReconciler.deleteByManagedEntity with protection check before deletion
- Wire Protection config into LeaseReconciler from main.go
- Remove default values for protection.resourcepools (no pools protected by default; targets are hardcoded)
- Update tests, sample config, and documentation