### PR TITLE
feat: add configurable VM name prefix protection for port group cleanup

### DIFF
--- a/config/samples/cleanup-config.yaml
+++ b/config/samples/cleanup-config.yaml
@@ -46,6 +46,10 @@ data:
       # even if they match the built-in target prefixes (ci-, qeci-).
       resourcepools:
         - ipi-ci-clusters
+      # Virtual machines matching these prefixes are protected from deletion
+      # during port group cleanup.
+      virtualmachines:
+        - kea-dhcp-
 
     logging:
       level: info

--- a/internal/controller/lease_controller.go
+++ b/internal/controller/lease_controller.go
@@ -242,6 +242,8 @@ func (r *LeaseReconciler) getFilteredVirtualMachines(ctx context.Context, moRefs
 			continue
 		case strings.HasPrefix(vm.Name, "rhcos-"):
 			continue
+		case IsProtectedVirtualMachine(vm.Name, r.Protection.VirtualMachines):
+			continue
 		}
 		toReturn = append(toReturn, vm)
 	}

--- a/internal/controller/protection.go
+++ b/internal/controller/protection.go
@@ -61,6 +61,17 @@ func IsProtectedResourcePool(rpName string, protectedPrefixes []string) bool {
 	return false
 }
 
+// IsProtectedVirtualMachine returns true if vmName starts with any of the protected prefixes.
+// Protected VMs are exempt from cleanup during port group deletion.
+func IsProtectedVirtualMachine(vmName string, protectedPrefixes []string) bool {
+	for _, prefix := range protectedPrefixes {
+		if strings.HasPrefix(vmName, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 // IsTargetStoragePolicy returns true if policyName starts with the given prefix.
 func IsTargetStoragePolicy(policyName string, prefix string) bool {
 	return strings.HasPrefix(policyName, prefix)

--- a/internal/controller/protection_test.go
+++ b/internal/controller/protection_test.go
@@ -142,6 +142,32 @@ var _ = Describe("Protection Helpers", func() {
 		})
 	})
 
+	Context("IsProtectedVirtualMachine", func() {
+		It("returns true when VM name matches a protected prefix", func() {
+			Expect(IsProtectedVirtualMachine("kea-dhcp-server1", []string{"kea-dhcp-"})).To(BeTrue())
+		})
+
+		It("returns false when VM name does not match any prefix", func() {
+			Expect(IsProtectedVirtualMachine("ci-test-vm", []string{"kea-dhcp-"})).To(BeFalse())
+		})
+
+		It("returns false when prefix list is empty", func() {
+			Expect(IsProtectedVirtualMachine("kea-dhcp-server1", []string{})).To(BeFalse())
+		})
+
+		It("returns false when VM name is empty", func() {
+			Expect(IsProtectedVirtualMachine("", []string{"kea-dhcp-"})).To(BeFalse())
+		})
+
+		It("matches against multiple prefixes", func() {
+			prefixes := []string{"kea-dhcp-", "infra-", "bastion-"}
+			Expect(IsProtectedVirtualMachine("kea-dhcp-server1", prefixes)).To(BeTrue())
+			Expect(IsProtectedVirtualMachine("infra-dns", prefixes)).To(BeTrue())
+			Expect(IsProtectedVirtualMachine("bastion-host", prefixes)).To(BeTrue())
+			Expect(IsProtectedVirtualMachine("ci-test-vm", prefixes)).To(BeFalse())
+		})
+	})
+
 	Context("IsTargetStoragePolicy", func() {
 		It("returns true when policy name has the prefix", func() {
 			Expect(IsTargetStoragePolicy("openshift-storage-policy-ci-123", "openshift-storage-policy-")).To(BeTrue())

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -15,9 +15,10 @@ import (
 // Folders: exact folder names to protect from deletion.
 // ResourcePools: resource pool name prefixes to protect from deletion.
 type ProtectionConfig struct {
-	Tags          []string `json:"tags"`
-	Folders       []string `json:"folders"`
-	ResourcePools []string `json:"resourcepools"`
+	Tags            []string `json:"tags"`
+	Folders         []string `json:"folders"`
+	ResourcePools   []string `json:"resourcepools"`
+	VirtualMachines []string `json:"virtualmachines"`
 }
 
 // SafetyConfig defines safety thresholds for cleanup operations.

--- a/pkg/utils/config_test.go
+++ b/pkg/utils/config_test.go
@@ -21,6 +21,9 @@ protection:
   resourcepools:
     - dev-
     - qa-
+  virtualmachines:
+    - kea-dhcp-
+    - bastion-
 safety:
   kubevols_min_age_days: 30
 `
@@ -37,6 +40,9 @@ safety:
 	}
 	if len(config.Protection.ResourcePools) != 2 || config.Protection.ResourcePools[0] != "dev-" {
 		t.Errorf("expected resourcepools [dev-, qa-], got %v", config.Protection.ResourcePools)
+	}
+	if len(config.Protection.VirtualMachines) != 2 || config.Protection.VirtualMachines[0] != "kea-dhcp-" {
+		t.Errorf("expected virtualmachines [kea-dhcp-, bastion-], got %v", config.Protection.VirtualMachines)
 	}
 	if config.Safety.KubevolsMinAgeDays != 30 {
 		t.Errorf("expected kubevols_min_age_days 30, got %d", config.Safety.KubevolsMinAgeDays)
@@ -55,6 +61,9 @@ func TestControllerConfig_ApplyDefaults(t *testing.T) {
 	}
 	if len(config.Protection.ResourcePools) != 0 {
 		t.Errorf("expected default resourcepools to be empty (no defaults), got %v", config.Protection.ResourcePools)
+	}
+	if len(config.Protection.VirtualMachines) != 0 {
+		t.Errorf("expected default virtualmachines to be empty (no defaults), got %v", config.Protection.VirtualMachines)
 	}
 	if config.Safety.KubevolsMinAgeDays != 21 {
 		t.Errorf("expected default kubevols_min_age_days 21, got %d", config.Safety.KubevolsMinAgeDays)


### PR DESCRIPTION
VMs matching configured prefixes (e.g. kea-dhcp-*) are now excluded from deletion during port group cleanup via protection.virtualmachines in the ConfigMap, following the same pattern as resource pool protection.